### PR TITLE
ci: add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  Awesome_Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: npx awesome-lint


### PR DESCRIPTION
This adds `awesome-lint` CI, which automatically reports issues that don't coincide with [awesome-lint](https://github.com/sindresorhus/awesome-lint).

Do note that this repository violates a few linting rules a lot, so if needs be, I can fix the issues:
- Don't bold links in each bullet point
- The link and the website are to be separated with a dash (though I do agree with yall's design -- maybe this can be raised as a separate issue in awesome-lint?)
- Badge source is invalid
- Invalid ToC
- Missing contribution guide

If you want to see for yourself, run `npx awesome-lint` on this (locally cloned) fork.

P.S: why are issues disabled in this repository?