### PR TITLE
Remove ModGradle and add PackDev

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Feel free to add your own project(s)—just fork and make a pull request! We sug
 ## Modpack creation tools
 
 - **[Kneelawk/PackVulcan](https://github.com/Kneelawk/PackVulcan)** - A GUI modpack builder for Modrinth and packwiz
-- **[ModdingX/PackDev](https://github.com/ModdingX/PackDev)** - A Gradle plugin for creating and running modpacks using ForgeGradle or loom.
+- **[ModdingX/PackDev](https://github.com/ModdingX/PackDev)** - A Gradle plugin for creating and running modpacks using ForgeGradle or Loom.
 - **[packwiz/packwiz](https://github.com/packwiz/packwiz)** - A command line tool for editing and distributing Minecraft modpacks, supporting Modrinth and CurseForge
 - **[RozeFound/mmc-export](https://github.com/RozeFound/mmc-export)** - A tool for exporting a MultiMC modpack to other formats
 - **[ryanccn/moddermore](https://github.com/ryanccn/moddermore)** ([Website](https://moddermore.vercel.app)) - A web app for creating public lists of mods exportable to `mrpack`s

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Feel free to add your own project(s)—just fork and make a pull request! We sug
 ## Modpack creation tools
 
 - **[Kneelawk/PackVulcan](https://github.com/Kneelawk/PackVulcan)** - A GUI modpack builder for Modrinth and packwiz
-- **[ModdingX/ModGradle](https://github.com/ModdingX/ModGradle)** - A Gradle plugin for creating and running Forge modpacks with ForgeGradle.
+- **[ModdingX/PackDev](https://github.com/ModdingX/PackDev)** - A Gradle plugin for creating and running modpacks using ForgeGradle or loom.
 - **[packwiz/packwiz](https://github.com/packwiz/packwiz)** - A command line tool for editing and distributing Minecraft modpacks, supporting Modrinth and CurseForge
 - **[RozeFound/mmc-export](https://github.com/RozeFound/mmc-export)** - A tool for exporting a MultiMC modpack to other formats
 - **[ryanccn/moddermore](https://github.com/ryanccn/moddermore)** ([Website](https://moddermore.vercel.app)) - A web app for creating public lists of mods exportable to `mrpack`s


### PR DESCRIPTION
PackDev, which was part of ModGradle before, has been extracted into a standalone project that now also works on fabric and quilt.
