### PR TITLE
Add modBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Feel free to add your own project(s)—just fork and make a pull request! We sug
 
 - **[mineblock11/android-modrinth-dashboard](https://github.com/mineblock11/android-modrinth-dashboard)** - An Android app for the Modrinth dashboard written in Vue
 - **[modrinth/knossos](https://github.com/modrinth/knossos)** ([Website](https://modrinth.com)) - The official Modrinth frontend we're all familiar with
+- **[worldwidepixel/modbar](https://github.com/worldwidepixel/modbar)** - A Chrome and Firefox extension which lets you search Modrinth from your titlebar
 - **[TheClashFruit/Rithle](https://github.com/TheClashFruit/Rithle)** - An Android app for Modrinth written in Kotlin
 
 ## Launchers


### PR DESCRIPTION
Add modBar to `modrinth/awesome`, a browser extension that lets you search and download Modrinth projects.