### PR TITLE
Add Shard Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Feel free to add your own project(s)—just fork and make a pull request! We sug
 - **[d3ara1n/Polymerium](https://github.com/d3ara1n/Polymerium)** - A next-generation Minecraft instance manager that thinks differently about game management
 - **[PrismLauncher/PrismLauncher](https://github.com/PrismLauncher/PrismLauncher)** - A power-user launcher for Minecraft that allows you to easily manage multiple installations at once (fork of MultiMC)
 - **[QuestCraftPlusPlus/QuestCraft](https://github.com/QuestCraftPlusPlus/QuestCraft)** - A port of Minecraft: Java Edition to the Meta Quest Platform
+- **[Th0rgal/shard](https://github.com/Th0rgal/shard)** - Open-source Minecraft launcher with declarative profiles, content-addressed storage, and Modrinth integration
 - **[Voxelum/x-minecraft-launcher](https://github.com/Voxelum/x-minecraft-launcher)** - A Minecraft launcher focusing on modern UX and disk efficiency
 
 ## Libraries


### PR DESCRIPTION
Added Shard Launcher to the Launchers section in alphabetical order.

Shard is an open-source Minecraft launcher with declarative JSON profiles, content-addressed storage for deduplication, and Modrinth integration.

Source: https://github.com/Th0rgal/shard

Thank you for maintaining this list.